### PR TITLE
Update windows paths in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Execute the macro from FreeCAD. If you need help, look at: https://wiki.freecadw
 The macro mostly change colors and some minor settings.
 
 ### Windows
-`C:\Documents and Settings\username\Application Data\FreeCAD\Macro`
+`C:\Users\username\AppData\Roaming\FreeCAD\Macro`
+
+or with environment variable:
+
+`%appdata%\FreeCAD\Macro`
 
 ### Linux & MacOS
 `~/.FreeCAD/Macro` 


### PR DESCRIPTION
Documents and settings folder doesn't exist since Windows Vista (2007). I guess this macro isn't targeted for XP or NT users only 😂

Updated docs to the current correct paths. If you don't like the `%appdata%` version, you can delete it, but I always access appdata folder this way, it's quicker and works regardless of username, just like `~` in *nix, but it can be confusing for users not familiar with environment variables.